### PR TITLE
Feature/45 성공 및 에러 메세지를 enum으로 관리

### DIFF
--- a/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/controller/ApiV1ItemController.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/controller/ApiV1ItemController.java
@@ -4,11 +4,11 @@ import com.java.NBE4_5_1_8.domain.item.dto.ItemDto;
 import com.java.NBE4_5_1_8.domain.item.dto.ItemForm;
 import com.java.NBE4_5_1_8.domain.item.entity.Item;
 import com.java.NBE4_5_1_8.domain.item.service.ItemService;
+import com.java.NBE4_5_1_8.global.message.SuccessMessage;
 import com.java.NBE4_5_1_8.global.response.RsData;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,7 +27,7 @@ public class ApiV1ItemController {
         return RsData.success(
                 HttpStatus.OK,
                 new ItemDto(item),
-                "상품 등록 성공");
+                SuccessMessage.ITEM_CREATED);
     }
 
     @GetMapping
@@ -38,7 +38,7 @@ public class ApiV1ItemController {
                 items.stream()
                         .map(ItemDto::new)
                         .toList(),
-                "상품 조회 성공");
+                SuccessMessage.ITEM_LIST_FETCHED);
     }
 
     @GetMapping("/{itemId}")
@@ -49,7 +49,7 @@ public class ApiV1ItemController {
         return RsData.success(
                 HttpStatus.OK,
                 new ItemDto(item),
-                "상품 단건 조회 성공");
+                SuccessMessage.ITEM_FETCHED);
 
     }
 
@@ -62,7 +62,7 @@ public class ApiV1ItemController {
         return RsData.success(
                 HttpStatus.OK,
                 new ItemDto(item),
-                "상품 수정 성공");
+                SuccessMessage.ITEM_UPDATED);
     }
 
     @DeleteMapping("/{itemId}")
@@ -73,6 +73,6 @@ public class ApiV1ItemController {
 
         return RsData.success(
                 HttpStatus.OK,
-                "상품 삭제 성공");
+                SuccessMessage.ITEM_UPDATED);
     }
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/service/ItemService.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/service/ItemService.java
@@ -4,6 +4,7 @@ import com.java.NBE4_5_1_8.domain.item.dto.ItemForm;
 import com.java.NBE4_5_1_8.domain.item.entity.Item;
 import com.java.NBE4_5_1_8.domain.item.repository.ItemRepository;
 import com.java.NBE4_5_1_8.global.exception.ServiceException;
+import com.java.NBE4_5_1_8.global.message.ErrorMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -34,7 +35,7 @@ public class ItemService {
 
     public Item getItemById(Long itemId) {
         return itemRepository.findById(itemId)
-                .orElseThrow(() -> new ServiceException(HttpStatus.BAD_REQUEST, "존재하지 않는 상품입니다."));
+                .orElseThrow(() -> new ServiceException(HttpStatus.BAD_REQUEST, ErrorMessage.ITEM_NOT_FOUND));
     }
 
     public long count() {

--- a/backend/src/main/java/com/java/NBE4_5_1_8/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/global/exception/GlobalExceptionHandler.java
@@ -22,7 +22,7 @@ public class GlobalExceptionHandler {
                 .body(
                         RsData.failure(
                                 e.getStatusCode(),
-                                e.getMessage()
+                                e.getErrorMessage()
                         )
                 );
 
@@ -44,7 +44,7 @@ public class GlobalExceptionHandler {
                 .body(
                         RsData.failure(
                                 HttpStatus.BAD_REQUEST,
-                                message
+                                () -> message
                         )
                 );
     }

--- a/backend/src/main/java/com/java/NBE4_5_1_8/global/exception/ServiceException.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/global/exception/ServiceException.java
@@ -1,5 +1,6 @@
 package com.java.NBE4_5_1_8.global.exception;
 
+import com.java.NBE4_5_1_8.global.message.MessageType;
 import com.java.NBE4_5_1_8.global.response.RsData;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -9,12 +10,12 @@ public class ServiceException extends RuntimeException {
 
     private RsData<?> rsData;
 
-    public ServiceException(HttpStatus status, String message) {
-        super(message);
+    public ServiceException(HttpStatus status, MessageType message) {
+        super(message.getMessage());
         rsData = RsData.failure(status, message);
     }
 
-    public String getMessage() {
+    public MessageType getErrorMessage() {
         return rsData.getMessage();
     }
 

--- a/backend/src/main/java/com/java/NBE4_5_1_8/global/message/ErrorMessage.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/global/message/ErrorMessage.java
@@ -1,0 +1,15 @@
+package com.java.NBE4_5_1_8.global.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorMessage implements MessageType{
+    ITEM_NOT_FOUND("존재하지 않는 상품입니다."),
+    ORDER_NOT_FOUND("존재하지 않는 주문입니다."),
+    INVALID_REQUEST("잘못된 요청입니다."),
+    ITEM_CANNOT_BE_DELETED("주문된 상품은 삭제할 수 없습니다.");
+
+    private final String message;
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_8/global/message/MessageType.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/global/message/MessageType.java
@@ -1,5 +1,8 @@
 package com.java.NBE4_5_1_8.global.message;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public interface MessageType {
+    @JsonValue
     String getMessage();
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_8/global/message/MessageType.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/global/message/MessageType.java
@@ -1,0 +1,5 @@
+package com.java.NBE4_5_1_8.global.message;
+
+public interface MessageType {
+    String getMessage();
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_8/global/message/SuccessMessage.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/global/message/SuccessMessage.java
@@ -1,0 +1,16 @@
+package com.java.NBE4_5_1_8.global.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessMessage implements MessageType{
+    ITEM_CREATED("상품 등록 성공"),
+    ITEM_UPDATED("상품 수정 성공"),
+    ITEM_DELETED("상품 삭제 성공"),
+    ITEM_FETCHED("상품 단건 조회 성공"),
+    ITEM_LIST_FETCHED("상품 목록 조회 성공");
+
+    private final String message;
+}

--- a/backend/src/main/java/com/java/NBE4_5_1_8/global/response/RsData.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/global/response/RsData.java
@@ -2,6 +2,7 @@ package com.java.NBE4_5_1_8.global.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.java.NBE4_5_1_8.global.message.MessageType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.http.HttpStatus;
@@ -12,18 +13,18 @@ import org.springframework.http.HttpStatus;
 public class RsData<T> {
     private HttpStatus status;
     private boolean success;
-    private String message;
+    private MessageType message;
     private T data;
 
-    public static <T> RsData<T> success(HttpStatus status, String message) {
+    public static <T> RsData<T> success(HttpStatus status, MessageType message) {
         return new RsData<>(status, true, message, null);
     }
 
-    public static <T> RsData<T> success(HttpStatus status, T data, String message) {
+    public static <T> RsData<T> success(HttpStatus status, T data, MessageType message) {
         return new RsData<>(status, true, message, data);
     }
 
-    public static <T> RsData<T> failure(HttpStatus status, String message) {
+    public static <T> RsData<T> failure(HttpStatus status, MessageType message) {
         return new RsData<>(status, false, message, null);
     }
 

--- a/backend/src/main/java/com/java/NBE4_5_1_8/global/response/RsData.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/global/response/RsData.java
@@ -1,10 +1,10 @@
 package com.java.NBE4_5_1_8.global.response;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.java.NBE4_5_1_8.global.message.MessageType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 public class RsData<T> {
     private HttpStatus status;
     private boolean success;
+    @Getter
     private MessageType message;
     private T data;
 


### PR DESCRIPTION

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

global 패키지에 message enum 클래스를 생성하여
"존재하지 않는 상품입니다" 등 string 형태로 작성되던 코드를
enum 형태로 일관될 수 있도록 구현


## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
![image](https://github.com/user-attachments/assets/4f2f82fb-4650-4a0f-93ba-5e4c3edee943)

에러 메세지의 경우에도 ErrorMessage.ITEM_NOT_FOUND 등의 형태로 사용하면 될 것 같습니다

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
더 나은 방식 혹은 개선 사항이나 부족한 부분 피드백 부탁드립니다.
