### PR TITLE
Feature/51 주문 내역이 있는 상품 삭제 시 예외 처리

### DIFF
--- a/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/controller/ApiV1ItemController.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/controller/ApiV1ItemController.java
@@ -72,6 +72,6 @@ public class ApiV1ItemController {
 
         return RsData.success(
                 HttpStatus.OK,
-                SuccessMessage.ITEM_UPDATED);
+                SuccessMessage.ITEM_DELETED);
     }
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/entity/Item.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/entity/Item.java
@@ -25,4 +25,7 @@ public class Item extends BaseTime {
 
     @OneToMany(mappedBy = "item")
     private List<OrderItem> orderItems;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/repository/ItemRepository.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/repository/ItemRepository.java
@@ -4,6 +4,9 @@ import com.java.NBE4_5_1_8.domain.item.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long> {
+    List<Item> findAllByDeletedFalse();
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/service/ItemService.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/service/ItemService.java
@@ -5,6 +5,7 @@ import com.java.NBE4_5_1_8.domain.item.entity.Category;
 import com.java.NBE4_5_1_8.domain.item.entity.Item;
 import com.java.NBE4_5_1_8.domain.item.repository.CategoryRepository;
 import com.java.NBE4_5_1_8.domain.item.repository.ItemRepository;
+import com.java.NBE4_5_1_8.domain.orderitem.repository.OrderItemRepository;
 import com.java.NBE4_5_1_8.global.exception.ServiceException;
 import com.java.NBE4_5_1_8.global.message.ErrorMessage;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ import java.util.List;
 public class ItemService {
     private final ItemRepository itemRepository;
     private final CategoryRepository categoryRepository;
+    private final OrderItemRepository orderItemRepository;
 
     @Value("${file.upload-dir}")
     private String itemsDir;
@@ -110,6 +112,12 @@ public class ItemService {
     }
 
     public void deleteItem(Item item) {
+
+        boolean hasOrderHistory = orderItemRepository.existsByItem(item);
+        if (hasOrderHistory) {
+            throw new ServiceException(HttpStatus.BAD_REQUEST, ErrorMessage.ITEM_CANNOT_BE_DELETED);
+        }
+
         itemRepository.delete(item);
     }
 

--- a/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/service/ItemService.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/domain/item/service/ItemService.java
@@ -5,7 +5,7 @@ import com.java.NBE4_5_1_8.domain.item.entity.Category;
 import com.java.NBE4_5_1_8.domain.item.entity.Item;
 import com.java.NBE4_5_1_8.domain.item.repository.CategoryRepository;
 import com.java.NBE4_5_1_8.domain.item.repository.ItemRepository;
-import com.java.NBE4_5_1_8.domain.orderitem.repository.OrderItemRepository;
+import com.java.NBE4_5_1_8.domain.orderinfo.repository.OrderItemRepository;
 import com.java.NBE4_5_1_8.global.exception.ServiceException;
 import com.java.NBE4_5_1_8.global.message.ErrorMessage;
 import lombok.RequiredArgsConstructor;
@@ -83,7 +83,7 @@ public class ItemService {
     }
 
     public List<Item> getItemList() {
-        return itemRepository.findAll();
+        return itemRepository.findAllByDeletedFalse();
     }
 
     public Item getItemById(Long itemId) {
@@ -115,7 +115,9 @@ public class ItemService {
 
         boolean hasOrderHistory = orderItemRepository.existsByItem(item);
         if (hasOrderHistory) {
-            throw new ServiceException(HttpStatus.BAD_REQUEST, ErrorMessage.ITEM_CANNOT_BE_DELETED);
+            item.setDeleted(true);
+            itemRepository.save(item);
+            throw new ServiceException(HttpStatus.OK, ErrorMessage.ITEM_BE_DISABLED);
         }
 
         itemRepository.delete(item);

--- a/backend/src/main/java/com/java/NBE4_5_1_8/domain/orderinfo/repository/OrderItemRepository.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/domain/orderinfo/repository/OrderItemRepository.java
@@ -1,5 +1,6 @@
 package com.java.NBE4_5_1_8.domain.orderinfo.repository;
 
+import com.java.NBE4_5_1_8.domain.item.entity.Item;
 import com.java.NBE4_5_1_8.domain.orderinfo.entity.OrderInfo;
 import com.java.NBE4_5_1_8.domain.orderinfo.entity.OrderItem;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import java.util.List;
 @Repository
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
     List<OrderItem> findAllByOrderInfo(OrderInfo orderInfo);
+
+    boolean existsByItem(Item item);
 }

--- a/backend/src/main/java/com/java/NBE4_5_1_8/global/message/ErrorMessage.java
+++ b/backend/src/main/java/com/java/NBE4_5_1_8/global/message/ErrorMessage.java
@@ -12,7 +12,8 @@ public enum ErrorMessage implements MessageType{
     ITEM_CANNOT_BE_DELETED("주문된 상품은 삭제할 수 없습니다."),
     ORDER_CANNOT_BE_DELETED("삭제 불가능한 주문입니다."),
     CATEGORY_NOT_FOUND("존재하지 않는 카테고리입니다."),
-    CATEGORY_ALREADY_EXISTS("이미 존재하는 카테고리입니다.");
+    CATEGORY_ALREADY_EXISTS("이미 존재하는 카테고리입니다."),
+    ITEM_BE_DISABLED("주문 내역이 있는 상품은 비활성화 처리되었습니다.");
 
 
     private final String message;


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
### 주문 내역이 있는 상품 삭제 시 예외 처리
주문 내역이 존재하는 상품을 삭제하고자 할 때 삭제하지 못하도록 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. 삭제 구현 Controller에서 UPDATED 로 되어있더라구요 DELETED로 수정 했습니다!
2. 이미 주문 저장소(repository)에 존재한다면 throw 로 삭제 못하게 예외 처리 하였습니다.
![image](https://github.com/user-attachments/assets/9afebdf1-c2e0-43c6-bdf4-15cb7962c496)

## ✅ 피드백 반영사항
직접 DB에 삭제하는게 아닌, deleted 라는 필드를 생성해서 주문 내역이 있는 상품 삭제 시 true로 반영해서,
유저가 봤을때 보지못하게 구현해봤습니다.
![image](https://github.com/user-attachments/assets/3836d0af-e0d5-4bf3-ae0e-d12c382c9b4e)


+) 추가로 구현해야할 사항이 있다면 Delete된 상품을 다시 등록한다면 "상품이 다시 활성화되었습니다." 라는 것도 고려해봐야겠습니다..

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
제가 작성한거에 충돌 일어나서 당황..